### PR TITLE
Clarify README.md instructions for secure domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,13 @@ authenticated domain.
 -Dorg.jitsi.jicofo.auth.URL=XMPP:jitsi-meet.example.com
 ```
 
-If you have Jicofo installed from the Debian package this should go directly to
-**/etc/jitsi/jicofo/sip-communicator.properties** file:
+If you have Jicofo installed from the Debian package (either explicitly or by installing jitsi-meet) this should go directly to **/etc/jitsi/jicofo/sip-communicator.properties** file:
 ```
 org.jitsi.jicofo.auth.URL=XMPP:jitsi-meet.example.com
+```
+You will need to restart jicofo.  Try 
+```
+service jicofo restart
 ```
 
 4 To create users use the command:


### PR DESCRIPTION
Clarify instructions for secure domain to avoid this issue reported on the forum:
https://community.jitsi.org/t/secure-domain-enabled-but-still-no-password-requested/30107/5